### PR TITLE
Avoid repetition of content in incident response plan

### DIFF
--- a/res/sections/30-Les30052017.tex
+++ b/res/sections/30-Les30052017.tex
@@ -399,34 +399,28 @@ dell'incidente che a volte possono anche essere dolose.
 
 Questo piano si suddivide in diversi \textit{step}:
 \begin{enumerate}
-\item Preparazione;
-\item Identificazione;
-\item Contenimento;
-\item Analisi e eradicazione;
-\item Recupero;
-\item Imparare.
+\item \textbf{Preparazione}: Questa fase è la preparazione dell'incidente,
+corrisponde ad una fase di \textbf{analisi dello scenario};
+
+\item \textbf{Identificazione}: Questo step inizia quando si viene
+avvisati dell'anomalia e si comincia a cercare la causa del problema. 
+Più è ricco e complesso il sistema informativo, più è difficile trovare
+la causa del problema;
+
+\item \textbf{Contenimento}: In questa fase si cerca di ``limitare i 
+danni'', con l'obiettivo di mantenere l'operatività. Questo a volte 
+consiste in  sacrificare elementi della produttività;
+
+\item \textbf{Analisi e eradicazione}: Si cerca di capire cos'è successo
+e perché è successo, provando a risolvere la causa;
+
+\item \textbf{Recupero}: Si ritorna con i servizi di nuovo funzionanti,
+per ritornare alla fase di preparazione;
+
+\item \textbf{Imparare}:  Questa parte è molto importante, in quanto 
+imparare la lezione permette di evitare futuri attacchi e di rendere il
+sistema più sicuro.
+
 \end{enumerate}
 
-Vediamo brevemente il significato di ogni passo, che sarà analizzato in
-profondità più avanti.
-
-\paragraph*{Preparazione} Questa fase è la preparazione dell'incidente,
-corrisponde ad una fase di \textbf{analisi dello scenario}.
-
-\paragraph*{Identificazione} Questo step inizia quando si viene
-avvisati dell'anomalia e si comincia a cercare la causa del problema. Più è
-ricco e complesso il sistema informativo, più è difficile trovare la causa del
-problema.
-
-\paragraph*{Contenimento} In questa fase si cerca di ``limitare i danni'', con
-l'obiettivo di mantenere l'operatività. Questo a volte consiste in sacrificare
-elementi della produttività.
-
-\paragraph*{Analisi e eradicazione} Si cerca di capire cos'è successo e perché
-è successo, provando a risolvere la causa.
-
-\paragraph*{Recupero} Si ritorna con i servizi di nuovo funzionanti, per
-ritornare alla fase di preparazione.
-
-\paragraph*{Imparare} Questa parte è molto importante, in quanto imparare la
-lezione permette di evitare futuri attacchi e di rendere il sistema più sicuro.
+Di seguito ogni passo verrà analizzato in maggiore dettaglio.


### PR DESCRIPTION
**Reference to the issue (_mandatory_)**: closes #
Con questo commit si evita di ripetere 3 volte gli step dell'incident response plan. 
addirittura si potrebbe evitare di ripeterlo due volte e mergiare direttamente la descrizione breve con quella lunga. 


**Description**
